### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/docs/src/examples/ui/action/action-6.vue
+++ b/docs/src/examples/ui/action/action-6.vue
@@ -100,7 +100,7 @@
   }
 
   .fill {
-    background-image: url('https://source.unsplash.com/random/150x150');
+    background-image: url('https://picsum.photos/150/150');
     height: 145px;
     width: 145px;
     cursor: pointer;


### PR DESCRIPTION
`docs/src/examples/ui/action/action-6.vue` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns 503 errors. Browser screenshots typically render a broken image icon instead of the intended placeholder.

You can verify in any browser:

```
curl -I https://source.unsplash.com/random/800x600?office
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Replaces the broken background-image URL in the docs `action-6.vue` example with a working `picsum.photos` URL of the same size.

#### Replacement details

Direct, dependency-free swap — same image dimensions, no behaviour change apart from the image now actually loading.

#### Background

I'm tracking deprecated image-CDN URLs across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built to make it easy to drop real Unsplash photos into projects without registering an Unsplash app or managing API keys. tteg isn't a dependency of this PR — the fix above is dependency-free. But if you ever want to swap the static replacement for something topic-aware, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

A 16k-files-across-885-repos summary of the deprecation is at [`kiluazen/tteg/RESEARCH.md`](https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md).
