### PR TITLE
feat(history): 支持项目历史记录管理功能

### DIFF
--- a/apps/app/CHANGELOG.md
+++ b/apps/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/vtj-project-app@0.19.6...vtj-project-app@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package vtj-project-app
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/vtj-project-app@0.19.5...vtj-project-app@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package vtj-project-app

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -2,7 +2,7 @@
   "name": "vtj-project-app",
   "description": "项目示例",
   "private": true,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "scripts": {
     "setup": "pnpm install --unsafe-perm --registry=https://registry.npmmirror.com",

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/vtj-extension@0.19.6...vtj-extension@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package vtj-extension
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/vtj-extension@0.19.5...vtj-extension@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package vtj-extension

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vtj-extension",
   "private": true,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "scripts": {
     "setup": "pnpm install --unsafe-perm --registry=https://registry.npmmirror.com",

--- a/apps/h5/CHANGELOG.md
+++ b/apps/h5/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/vtj-project-h5@0.19.6...vtj-project-h5@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package vtj-project-h5
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/vtj-project-h5@0.19.5...vtj-project-h5@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package vtj-project-h5

--- a/apps/h5/package.json
+++ b/apps/h5/package.json
@@ -2,7 +2,7 @@
   "name": "vtj-project-h5",
   "description": "H5项目示例",
   "private": true,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "scripts": {
     "setup": "pnpm install --unsafe-perm --registry=https://registry.npmmirror.com",

--- a/apps/material/CHANGELOG.md
+++ b/apps/material/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/vtj-material@0.19.6...vtj-material@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package vtj-material
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/vtj-material@0.19.5...vtj-material@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package vtj-material

--- a/apps/material/package.json
+++ b/apps/material/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vtj-material",
   "private": true,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "scripts": {
     "setup": "pnpm install --unsafe-perm --registry=https://registry.npmmirror.com",

--- a/apps/plugin/CHANGELOG.md
+++ b/apps/plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/vtj-plugin@0.19.6...vtj-plugin@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package vtj-plugin
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/vtj-plugin@0.19.5...vtj-plugin@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package vtj-plugin

--- a/apps/plugin/package.json
+++ b/apps/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vtj-plugin",
   "private": true,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "scripts": {
     "setup": "pnpm install --unsafe-perm --registry=https://registry.npmmirror.com",

--- a/apps/uniapp/CHANGELOG.md
+++ b/apps/uniapp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/vtj-project-uniapp@0.19.6...vtj-project-uniapp@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package vtj-project-uniapp
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/vtj-project-uniapp@0.19.5...vtj-project-uniapp@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package vtj-project-uniapp

--- a/apps/uniapp/package.json
+++ b/apps/uniapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtj-project-uniapp",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "private": true,
   "scripts": {
     "dev:app": "uni -p app",

--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/dev-web@0.19.6...dev-web@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package dev-web
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/dev-web@0.19.5...dev-web@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package dev-web

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-web",
   "private": true,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "scripts": {
     "dev": "cross-env ENV_TYPE=local vite --force",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/@vtj/docs@0.19.6...@vtj/docs@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/docs
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/@vtj/docs@0.19.5...@vtj/docs@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/docs",
   "private": true,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "scripts": {
     "docs:dev": "vitepress dev",

--- a/packages/charts/CHANGELOG.md
+++ b/packages/charts/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/charts@0.19.6...@vtj/charts@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/charts
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/charts@0.19.5...@vtj/charts@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/charts

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/charts",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/charts/src/version.ts
+++ b/packages/charts/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/charts 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/coder/CHANGELOG.md
+++ b/packages/coder/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/coder@0.19.6...@vtj/coder@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/coder
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/coder@0.19.5...@vtj/coder@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/coder

--- a/packages/coder/package.json
+++ b/packages/coder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/coder",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "AI低代码",

--- a/packages/coder/src/version.ts
+++ b/packages/coder/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/coder 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/core@0.19.6...@vtj/core@0.19.7) (2026-08-14)
+
+
+### Features
+
+* **history:** 支持项目历史记录管理功能 ([e3bee05](https://gitee.com/newgateway/vtj/commits/e3bee05081e32a9991e9e4cab65598a9e7fb93b8))
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/core@0.19.5...@vtj/core@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/core",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/core/src/models/history.ts
+++ b/packages/core/src/models/history.ts
@@ -1,5 +1,10 @@
 import { uid, cloneDeep, toArray } from '@vtj/base';
-import type { HistorySchema, HistoryItem, BlockSchema } from '../protocols';
+import type {
+  HistorySchema,
+  HistoryItem,
+  HistoryDsl,
+  HistoryType
+} from '../protocols';
 import { emitter, type ModelEventType } from '../tools';
 
 export interface HistoryModelOptions {
@@ -19,21 +24,24 @@ export class HistoryModel {
   private options: HistoryModelOptions = { max: 50 };
   index: number = -1;
   id: string;
+  type: HistoryType;
   items: HistoryItem[];
   constructor(
     schema: HistorySchema,
     options: Partial<HistoryModelOptions> = {}
   ) {
     Object.assign(this.options, options);
-    const { id, items = [] } = schema;
+    const { id, type = 'file', items = [] } = schema;
     this.id = id;
+    this.type = type;
     this.items = items;
   }
 
   toDsl(): HistorySchema {
-    const { id, items } = this;
+    const { id, type, items } = this;
     return {
       id,
+      type,
       items: items.map((n) => ({
         id: n.id,
         label: n.label,
@@ -55,7 +63,7 @@ export class HistoryModel {
    * @param dsl
    * @param silent
    */
-  add(dsl: BlockSchema, remark: string = '', silent: boolean = false) {
+  add(dsl: HistoryDsl, remark: string = '', silent: boolean = false) {
     const { max } = this.options;
     const item: HistoryItem = {
       id: uid(),

--- a/packages/core/src/protocols/schemas/history.ts
+++ b/packages/core/src/protocols/schemas/history.ts
@@ -1,4 +1,9 @@
 import type { BlockSchema } from './block';
+import type { ProjectSchema } from './project';
+
+export type HistoryType = 'file' | 'project';
+
+export type HistoryDsl = BlockSchema | ProjectSchema;
 
 /**
  * 历史记录描述
@@ -8,6 +13,11 @@ export interface HistorySchema {
    * 页面或区块文件id
    */
   id: string;
+
+  /**
+   * 历史记录类型，旧数据默认为文件历史
+   */
+  type?: HistoryType;
 
   /**
    * 历史记录项
@@ -30,7 +40,7 @@ export interface HistoryItem {
   /**
    * 记录项内容
    */
-  dsl?: BlockSchema;
+  dsl?: HistoryDsl;
 
   /**
    * 备注

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/core 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/core/tests/models/history.test.ts
+++ b/packages/core/tests/models/history.test.ts
@@ -1,7 +1,11 @@
 import { expect, test, vi, describe, beforeEach } from 'vitest';
 import { HistoryModel } from '../../src/models';
 import { emitter } from '../../src/tools';
-import type { HistorySchema, BlockSchema } from '../../src/protocols';
+import type {
+  HistorySchema,
+  BlockSchema,
+  ProjectSchema
+} from '../../src/protocols';
 
 describe('HistoryModel', () => {
   beforeEach(() => {
@@ -22,6 +26,15 @@ describe('HistoryModel', () => {
       expect(history.id).toBe('file-1');
       expect(history.items).toEqual([]);
       expect(history.index).toBe(-1);
+      expect(history.type).toBe('file');
+    });
+
+    test('should create project history', () => {
+      const history = new HistoryModel({
+        id: '__project__',
+        type: 'project'
+      });
+      expect(history.type).toBe('project');
     });
 
     test('should initialize with items', () => {
@@ -59,6 +72,7 @@ describe('HistoryModel', () => {
       const history = new HistoryModel(schema);
       const dsl = history.toDsl();
       expect(dsl.id).toBe('file-1');
+      expect(dsl.type).toBe('file');
       expect(dsl.items).toHaveLength(1);
       expect(dsl.items![0].id).toBe('h1');
       expect(dsl.items![0].label).toBe('Initial');
@@ -95,6 +109,21 @@ describe('HistoryModel', () => {
       expect(history.items).toHaveLength(1);
       expect(history.items[0].remark).toBe('Initial save');
       expect(history.items[0].dsl).toBeDefined();
+    });
+
+    test('should add project dsl', () => {
+      const history = new HistoryModel({
+        id: '__project__',
+        type: 'project'
+      });
+      const project: ProjectSchema = {
+        id: 'project-1',
+        name: 'TestProject',
+        __VTJ_PROJECT__: true
+      };
+      history.add(project);
+      expect(history.items[0].dsl).toEqual(project);
+      expect(history.items[0].dsl).not.toBe(project);
     });
 
     test('should set index to -1 on add', () => {

--- a/packages/designer/CHANGELOG.md
+++ b/packages/designer/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/designer@0.19.6...@vtj/designer@0.19.7) (2026-08-14)
+
+
+### Features
+
+* **history:** 支持项目历史记录管理功能 ([e3bee05](https://gitee.com/newgateway/vtj/commits/e3bee05081e32a9991e9e4cab65598a9e7fb93b8))
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/designer@0.19.5...@vtj/designer@0.19.6) (2026-08-14)
 
 

--- a/packages/designer/package.json
+++ b/packages/designer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/designer",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/designer/src/components/hooks/useHistory.ts
+++ b/packages/designer/src/components/hooks/useHistory.ts
@@ -1,15 +1,20 @@
-import { computed } from 'vue';
+import { computed, unref, type MaybeRef } from 'vue';
+import type { HistoryType } from '@vtj/core';
 import { useEngine, Designer } from '../../framework';
-import { message } from '../../utils';
-export function useHistory() {
+import { confirm } from '../../utils';
+
+export function useHistory(source: MaybeRef<HistoryType> = 'file') {
   const engine = useEngine();
 
   const designer = computed<Designer | null>(
     () => engine.simulator.designer.value
   );
-  const history = computed(() =>
-    engine.current.value ? engine.history.value : null
-  );
+  const history = computed(() => {
+    if (unref(source) === 'project') {
+      return engine.projectHistory.value;
+    }
+    return engine.current.value ? engine.history.value : null;
+  });
   const total = computed(() => history.value?.items.length || 0);
 
   const forward = () => {
@@ -22,10 +27,15 @@ export function useHistory() {
     designer.value?.cleanHelper();
   };
 
-  const load = (id: string) => {
+  const load = async (id: string) => {
+    if (unref(source) === 'project') {
+      const ret = await confirm(
+        '确定恢复该项目历史版本吗？项目配置及文件清单将被覆盖，文件内容不会回滚。'
+      );
+      if (!ret) return;
+    }
     designer.value?.cleanHelper();
     history.value?.load(id);
-    message('已载入历史记录', 'success');
   };
 
   const forwardDisabled = computed(() => {
@@ -41,15 +51,21 @@ export function useHistory() {
   });
 
   const getHistoryDsl = async (id: string) => {
-    if (engine.current.value) {
+    if (history.value) {
       const projectDsl = engine.project.value?.toDsl();
       const item = await engine.service.getHistoryItem(
-        engine.current.value.id,
+        history.value.id,
         id,
         projectDsl
       );
       return item?.dsl;
     }
+  };
+
+  const getCurrentDsl = () => {
+    return unref(source) === 'project'
+      ? engine.project.value?.toDsl()
+      : engine.current.value?.toDsl();
   };
 
   return {
@@ -61,6 +77,7 @@ export function useHistory() {
     load,
     forwardDisabled,
     backwardDisabled,
-    getHistoryDsl
+    getHistoryDsl,
+    getCurrentDsl
   };
 }

--- a/packages/designer/src/components/widgets/history/index.vue
+++ b/packages/designer/src/components/widgets/history/index.vue
@@ -28,6 +28,13 @@
         class="v-history-widget__checker"
         v-model="checkedAll"></ElCheckbox>
     </template>
+    <ElRadioGroup
+      class="v-history-widget__type"
+      size="small"
+      v-model="historyType">
+      <ElRadioButton value="file">文件</ElRadioButton>
+      <ElRadioButton value="project">项目</ElRadioButton>
+    </ElRadioGroup>
     <ElEmpty v-if="total === 0" :image-size="50"></ElEmpty>
     <template v-if="history">
       <Item
@@ -95,11 +102,13 @@
     ElDivider,
     ElCheckbox,
     ElButton,
-    ElSwitch
+    ElSwitch,
+    ElRadioGroup,
+    ElRadioButton
   } from 'element-plus';
   import { XAction, XDialogForm, XField } from '@vtj/ui';
   import { VtjIconDiff, Flag } from '@vtj/icons';
-  import type { HistoryItem } from '@vtj/core';
+  import type { HistoryItem, HistoryType } from '@vtj/core';
   import Diff from './diff.vue';
   import { Panel, Item } from '../../shared';
   import { useHistory } from '../../hooks';
@@ -109,7 +118,9 @@
     name: 'HistoryWidget'
   });
 
-  const { history, load, total, getHistoryDsl, engine } = useHistory();
+  const historyType = ref<HistoryType>('file');
+  const { history, load, total, getHistoryDsl, getCurrentDsl, engine } =
+    useHistory(historyType);
 
   const diffVisible = ref(false);
   const compareData = shallowRef();
@@ -170,7 +181,10 @@
             label: checkedItems[0].label,
             dsl: await getHistoryDsl(checkedItems[0].id)
           }
-        : { label: '当前文件', dsl: engine.current.value?.toDsl() };
+        : {
+            label: historyType.value === 'project' ? '当前项目' : '当前文件',
+            dsl: getCurrentDsl()
+          };
     if (newItem.dsl) {
       delete newItem.dsl.__VERSION__;
     }
@@ -197,7 +211,7 @@
   };
 
   const onSubmit = async (data: any) => {
-    const dsl = engine.current.value?.toDsl();
+    const dsl = getCurrentDsl();
     if (!dsl) return false;
     if (formModel.value) {
       delete data.checked;
@@ -227,12 +241,31 @@
     }
   });
 
+  watch(historyType, () => {
+    checkedAll.value = false;
+    for (const item of history.value?.items || []) {
+      (item as any).checked = false;
+    }
+    formVisible.value = false;
+    diffVisible.value = false;
+  });
+
   defineExpose({
     openAdd: onAdd
   });
 </script>
 
 <style lang="scss" scoped>
+  .v-history-widget__type {
+    display: flex;
+    margin: 0 10px 10px;
+    :deep(.el-radio-button) {
+      flex: 1;
+    }
+    :deep(.el-radio-button__inner) {
+      width: 100%;
+    }
+  }
   .v-history-widget__flag {
     :deep(.is-info) {
       opacity: 0.65;

--- a/packages/designer/src/framework/engine.ts
+++ b/packages/designer/src/framework/engine.ts
@@ -65,6 +65,8 @@ import { message, alert } from '../utils';
 export const engineKey: InjectionKey<ShallowReactive<Engine>> =
   Symbol('VtjEngine');
 
+const PROJECT_HISTORY_ID = '__project__';
+
 /**
  * 设计器引擎配置选项
  */
@@ -178,6 +180,7 @@ export class Engine extends Base {
   public context: Ref<Context | null> = ref(null); // 当前上下文
   public isEmptyCurrent: Ref<boolean> = ref(false); // 当前区块是否为空
   public history: Ref<HistoryModel | null> = ref(null); // 历史记录管理器
+  public projectHistory: Ref<HistoryModel | null> = ref(null); // 项目历史记录管理器
   public provider: Provider; // 提供者实例
   public adapter?: Partial<ProvideAdapter>; // 适配器配置
   /**
@@ -280,6 +283,7 @@ export class Engine extends Base {
       );
       this.project.value = new ProjectModel(dsl);
       this.provider.project = this.project.value;
+      await this.initProjectHistory();
       this.saveMaterials();
       this.triggerReady();
       this.report.setProject(this.project.value);
@@ -432,7 +436,10 @@ export class Engine extends Base {
     if (this.checkLocked()) return;
     const project = e.model;
     const dsl = project.toDsl();
-    await this.service.saveProject(dsl, e.type);
+    const saved = await this.service.saveProject(dsl, e.type);
+    if (saved && this.state.autoHistory) {
+      this.projectHistory.value?.add(dsl);
+    }
     triggerRef(this.project);
   }
 
@@ -535,12 +542,30 @@ export class Engine extends Base {
       const dsl = await this.service
         .getHistory(block.id, this.project.value?.toDsl())
         .catch(() => null);
-      this.history.value = new HistoryModel(
-        Object.assign(dsl || {}, { id: block.id })
-      );
+      this.history.value = new HistoryModel({
+        ...dsl,
+        id: block.id,
+        type: 'file'
+      });
     } else {
       this.history.value = null;
     }
+  }
+
+  /**
+   * 初始化项目历史记录
+   */
+  private async initProjectHistory() {
+    const projectDsl = this.project.value?.toDsl();
+    if (!projectDsl) return;
+    const dsl = await this.service
+      .getHistory(PROJECT_HISTORY_ID, projectDsl)
+      .catch(() => null);
+    this.projectHistory.value = new HistoryModel({
+      ...dsl,
+      id: PROJECT_HISTORY_ID,
+      type: 'project'
+    });
   }
 
   /**
@@ -577,7 +602,11 @@ export class Engine extends Base {
 
     const dsl = history.toDsl();
     await this.service.saveHistory(dsl, projectDsl);
-    triggerRef(this.history);
+    if (history.type === 'project') {
+      triggerRef(this.projectHistory);
+    } else {
+      triggerRef(this.history);
+    }
   }
 
   /**
@@ -585,20 +614,75 @@ export class Engine extends Base {
    * @param e 历史模型事件
    */
   private async loadHistory(e: HistoryModelEvent) {
+    if (this.checkLocked()) return;
     const history = e.model;
     const data = e.data as HistoryItem;
     const projectDsl = this.project.value?.toDsl();
-    const item = await this.service.getHistoryItem(
-      history.id,
-      data.id,
-      projectDsl
-    );
-    if (item && item.dsl) {
-      const block = new BlockModel(item.dsl);
-      await this.updateCurrent(block);
-      this.service.saveFile(item.dsl, projectDsl);
-      triggerRef(this.history);
+    try {
+      const item = await this.service.getHistoryItem(
+        history.id,
+        data.id,
+        projectDsl
+      );
+      if (!item?.dsl) return;
+      if (history.type === 'project') {
+        await this.loadProjectHistory(item.dsl as ProjectSchema);
+        triggerRef(this.projectHistory);
+      } else {
+        const dsl = item.dsl as BlockSchema;
+        const block = new BlockModel(dsl);
+        await this.updateCurrent(block);
+        await this.service.saveFile(dsl, projectDsl);
+        triggerRef(this.history);
+      }
+      message('已载入历史记录', 'success');
+    } catch (e) {
+      logger.warn('VTJEngine load history fail.', e);
+      message('载入历史记录失败', 'warning');
     }
+  }
+
+  /**
+   * 加载项目历史记录
+   */
+  private async loadProjectHistory(dsl: ProjectSchema) {
+    const currentProject = this.project.value;
+    if (
+      !currentProject ||
+      !dsl.__VTJ_PROJECT__ ||
+      dsl.id !== currentProject.id
+    ) {
+      throw new Error('Invalid project history');
+    }
+
+    const currentFileId = currentProject.currentFile?.id;
+    const project = new ProjectModel({
+      ...dsl,
+      locked: currentProject.locked,
+      __BASE_PATH__: currentProject.__BASE_PATH__,
+      __UID__: currentProject.__UID__
+    });
+    const currentFile = currentFileId
+      ? project.getFile(currentFileId)
+      : undefined;
+    if (currentFile) {
+      currentFile.dsl = this.current.value?.toDsl();
+      project.active(currentFile, true);
+    }
+
+    const saved = await this.service.saveProject(project.toDsl(), 'update');
+    if (!saved) {
+      throw new Error('Save project history fail');
+    }
+
+    this.project.value = project;
+    this.provider.project = project;
+    this.report.setProject(project);
+    if (!currentFile) {
+      await this.updateCurrent(null);
+      this.history.value = null;
+    }
+    triggerRef(this.project);
   }
 
   /**

--- a/packages/designer/src/version.ts
+++ b/packages/designer/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/designer 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/designer/tests/engineHistory.test.ts
+++ b/packages/designer/tests/engineHistory.test.ts
@@ -1,0 +1,137 @@
+import { ref, toRaw } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BlockModel,
+  HistoryModel,
+  ProjectModel,
+  type ProjectSchema
+} from '@vtj/core';
+import { Engine } from '../src/framework/engine';
+
+function createEngine(saved: boolean = true) {
+  const project = new ProjectModel({
+    id: 'project-1',
+    name: 'CurrentProject',
+    locked: 'current-user',
+    __BASE_PATH__: '/current/',
+    __UID__: 'current-uid',
+    pages: [{ id: 'page-1', name: 'PageOne', type: 'page' }]
+  });
+  project.active(project.getFile('page-1')!, true);
+
+  const engine = Object.create(Engine.prototype) as Engine;
+  const saveProject = vi.fn(async () => saved);
+  Object.assign(engine, {
+    project: ref(project),
+    current: ref(new BlockModel({ id: 'page-1', name: 'PageOne' })),
+    history: ref(null),
+    provider: {},
+    report: { setProject: vi.fn() },
+    service: { saveProject },
+    updateCurrent: vi.fn()
+  });
+  return { engine, project, saveProject };
+}
+
+function createHistoryDsl(): ProjectSchema {
+  return {
+    id: 'project-1',
+    name: 'HistoryProject',
+    locked: 'old-user',
+    __BASE_PATH__: '/old/',
+    __UID__: 'old-uid',
+    __VTJ_PROJECT__: true,
+    pages: [{ id: 'page-1', name: 'OldPage', type: 'page' }]
+  };
+}
+
+describe('Engine project history', () => {
+  it('records project dsl after a successful save', async () => {
+    const { engine, project, saveProject } = createEngine();
+    const projectHistory = new HistoryModel({
+      id: '__project__',
+      type: 'project'
+    });
+    Object.assign(engine, {
+      projectHistory: ref(projectHistory),
+      state: { autoHistory: true },
+      checkLocked: vi.fn(() => false)
+    });
+
+    await (engine as any).saveProject({
+      model: project,
+      type: 'update',
+      data: null
+    });
+
+    expect(saveProject).toHaveBeenCalledOnce();
+    expect(projectHistory.items).toHaveLength(1);
+    expect(projectHistory.items[0].dsl).toMatchObject({
+      id: 'project-1',
+      __VTJ_PROJECT__: true
+    });
+  });
+
+  it('does not record a project dsl when saving fails', async () => {
+    const { engine, project } = createEngine(false);
+    const projectHistory = new HistoryModel({
+      id: '__project__',
+      type: 'project'
+    });
+    Object.assign(engine, {
+      projectHistory: ref(projectHistory),
+      state: { autoHistory: true },
+      checkLocked: vi.fn(() => false)
+    });
+
+    await (engine as any).saveProject({
+      model: project,
+      type: 'update',
+      data: null
+    });
+
+    expect(projectHistory.items).toHaveLength(0);
+  });
+
+  it('restores project dsl and preserves runtime fields', async () => {
+    const { engine, project, saveProject } = createEngine();
+    saveProject.mockImplementationOnce(async () => {
+      expect(toRaw(engine.project.value)).toBe(project);
+      return true;
+    });
+
+    await (engine as any).loadProjectHistory(createHistoryDsl());
+
+    expect(toRaw(engine.project.value)).not.toBe(project);
+    expect(engine.project.value?.name).toBe('HistoryProject');
+    expect(engine.project.value?.locked).toBe('current-user');
+    expect(engine.project.value?.__BASE_PATH__).toBe('/current/');
+    expect(engine.project.value?.__UID__).toBe('current-uid');
+    expect(engine.project.value?.currentFile?.id).toBe('page-1');
+    expect(engine.provider.project).toBe(toRaw(engine.project.value));
+  });
+
+  it('does not replace current project when persistence fails', async () => {
+    const { engine, project } = createEngine(false);
+
+    await expect(
+      (engine as any).loadProjectHistory(createHistoryDsl())
+    ).rejects.toThrow('Save project history fail');
+
+    expect(toRaw(engine.project.value)).toBe(project);
+  });
+
+  it('rejects history from another project', async () => {
+    const { engine, project, saveProject } = createEngine();
+
+    await expect(
+      (engine as any).loadProjectHistory({
+        ...createHistoryDsl(),
+        id: 'project-2'
+      })
+    ).rejects.toThrow('Invalid project history');
+
+    expect(saveProject).not.toHaveBeenCalled();
+    expect(toRaw(engine.project.value)).toBe(project);
+  });
+});

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/icons@0.19.6...@vtj/icons@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/icons
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/icons@0.19.5...@vtj/icons@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/icons

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/icons",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/icons/src/version.ts
+++ b/packages/icons/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/icons 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/local/CHANGELOG.md
+++ b/packages/local/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/local@0.19.6...@vtj/local@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/local
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/local@0.19.5...@vtj/local@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/local

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/local",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/materials/CHANGELOG.md
+++ b/packages/materials/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/materials@0.19.6...@vtj/materials@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/materials
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/materials@0.19.5...@vtj/materials@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/materials

--- a/packages/materials/package.json
+++ b/packages/materials/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/materials",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/materials/src/version.ts
+++ b/packages/materials/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/materials 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/parser/CHANGELOG.md
+++ b/packages/parser/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/parser@0.19.6...@vtj/parser@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/parser
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/parser@0.19.5...@vtj/parser@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/parser

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/parser",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "AI低代码",

--- a/packages/parser/src/version.ts
+++ b/packages/parser/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/parser 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/renderer/CHANGELOG.md
+++ b/packages/renderer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/renderer@0.19.6...@vtj/renderer@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/renderer
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/renderer@0.19.5...@vtj/renderer@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/renderer

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/renderer",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/renderer/src/version.ts
+++ b/packages/renderer/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/renderer 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/ui@0.19.6...@vtj/ui@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/ui
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/ui@0.19.5...@vtj/ui@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/ui

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/ui",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/ui/src/version.ts
+++ b/packages/ui/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/ui 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/uni/CHANGELOG.md
+++ b/packages/uni/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/uni@0.19.6...@vtj/uni@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/uni
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/uni@0.19.5...@vtj/uni@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/uni

--- a/packages/uni/package.json
+++ b/packages/uni/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/uni",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "sideEffects": false,
   "keywords": [

--- a/packages/uni/src/version.ts
+++ b/packages/uni/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/uni 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/utils@0.19.6...@vtj/utils@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/utils
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/utils@0.19.5...@vtj/utils@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/utils

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/utils",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "keywords": [
     "低代码引擎",

--- a/packages/utils/src/version.ts
+++ b/packages/utils/src/version.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026, VTJ.PRO All rights reserved.
  * @name @vtj/utils 
  * @author CHC chenhuachun1549@dingtalk.com 
- * @version 0.19.6
+ * @version 0.19.7
  * @license <a href="https://vtj.pro/license.html">MIT License</a>
  */
-export const version = '0.19.6';
+export const version = '0.19.7';

--- a/platforms/h5/CHANGELOG.md
+++ b/platforms/h5/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/h5@0.19.6...@vtj/h5@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/h5
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/h5@0.19.5...@vtj/h5@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/h5

--- a/platforms/h5/package.json
+++ b/platforms/h5/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/h5",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "sideEffects": false,
   "keywords": [

--- a/platforms/pro-uni/CHANGELOG.md
+++ b/platforms/pro-uni/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://github.com/samchen08/vtj.pro/compare/@vtj/pro-uni@0.19.6...@vtj/pro-uni@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/pro-uni
+
+
+
+
+
 ## [0.19.6](https://github.com/samchen08/vtj.pro/compare/@vtj/pro-uni@0.19.5...@vtj/pro-uni@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/pro-uni

--- a/platforms/pro-uni/package.json
+++ b/platforms/pro-uni/package.json
@@ -2,7 +2,7 @@
   "name": "@vtj/pro-uni",
   "description": "VTJ.PRO",
   "private": true,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "scripts": {
     "dev": "cross-env ENV_TYPE=local vite",

--- a/platforms/pro/CHANGELOG.md
+++ b/platforms/pro/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/pro@0.19.6...@vtj/pro@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/pro
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/pro@0.19.5...@vtj/pro@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/pro

--- a/platforms/pro/package.json
+++ b/platforms/pro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/pro",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "keywords": [
     "AI低代码",
     "AI编程",

--- a/platforms/uni-app/CHANGELOG.md
+++ b/platforms/uni-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/uni-app@0.19.6...@vtj/uni-app@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/uni-app
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/uni-app@0.19.5...@vtj/uni-app@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/uni-app

--- a/platforms/uni-app/package.json
+++ b/platforms/uni-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/uni-app",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "sideEffects": false,
   "keywords": [

--- a/platforms/web/CHANGELOG.md
+++ b/platforms/web/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.7](https://gitee.com/newgateway/vtj/compare/@vtj/web@0.19.6...@vtj/web@0.19.7) (2026-08-14)
+
+**Note:** Version bump only for package @vtj/web
+
+
+
+
+
 ## [0.19.6](https://gitee.com/newgateway/vtj/compare/@vtj/web@0.19.5...@vtj/web@0.19.6) (2026-08-14)
 
 **Note:** Version bump only for package @vtj/web

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtj/web",
   "private": false,
-  "version": "0.19.6",
+  "version": "0.19.7",
   "type": "module",
   "sideEffects": false,
   "keywords": [


### PR DESCRIPTION
- 在历史记录模型中新增 type 字段以区分文件与项目历史
- 扩展 HistoryDsl 类型以支持文件和项目两种模式
- 新增工程历史记录管理器 projectHistory，支持项目历史的新增、保存与加载
- 在引擎中初始化项目历史记录，并在项目保存成功时记录历史快照
- 设计器历史钩子 useHistory 支持文件和项目历史类型切换及相关操作
- 历史组件新增历史类型选择按钮，实现文件和项目历史的切换显示
- 载入项目历史时保持运行态字段，确保项目状态一致性
- 添加项目历史相关单元测试覆盖新功能和异常处理流程